### PR TITLE
update Basic Auth Lambda to node.js V10

### DIFF
--- a/aws/scripts/prov_server.json
+++ b/aws/scripts/prov_server.json
@@ -108,7 +108,7 @@
                         "};"
                     ]]}
                 },
-                "Runtime": "nodejs8.10"
+                "Runtime": "nodejs10.x"
             }
         },
         "BasicAuthEdgeLambdaVersion" : {


### PR DESCRIPTION
AWS discontinued support for node.js  v8.10. Need to move to v10.x 